### PR TITLE
fix: make scroll sync work on mobile/tablet previews

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,8 @@ export default function App() {
     const [scrollSyncEnabled, setScrollSyncEnabled] = useState(true);
     const previewRef = useRef<HTMLDivElement>(null);
     const editorScrollRef = useRef<HTMLTextAreaElement>(null);
-    const previewScrollRef = useRef<HTMLDivElement>(null);
+    const previewOuterScrollRef = useRef<HTMLDivElement>(null);
+    const previewInnerScrollRef = useRef<HTMLDivElement>(null);
     const scrollSyncLockRef = useRef<'editor' | 'preview' | null>(null);
     const scrollLockReleaseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -57,12 +58,25 @@ export default function App() {
     }, [scrollSyncEnabled]);
 
     useEffect(() => {
+        scrollSyncLockRef.current = null;
+        if (scrollLockReleaseTimeoutRef.current) {
+            clearTimeout(scrollLockReleaseTimeoutRef.current);
+            scrollLockReleaseTimeoutRef.current = null;
+        }
+    }, [previewDevice]);
+
+    useEffect(() => {
         return () => {
             if (scrollLockReleaseTimeoutRef.current) {
                 clearTimeout(scrollLockReleaseTimeoutRef.current);
             }
         };
     }, []);
+
+    const getActivePreviewScrollElement = () => {
+        if (previewDevice === 'pc') return previewOuterScrollRef.current;
+        return previewInnerScrollRef.current;
+    };
 
     const syncScrollPosition = (
         sourceElement: HTMLElement,
@@ -97,13 +111,22 @@ export default function App() {
 
     const handleEditorScroll = () => {
         const editorElement = editorScrollRef.current;
-        const previewElement = previewScrollRef.current;
+        const previewElement = getActivePreviewScrollElement();
         if (!editorElement || !previewElement) return;
         syncScrollPosition(editorElement, previewElement, 'editor');
     };
 
-    const handlePreviewScroll = () => {
-        const previewElement = previewScrollRef.current;
+    const handlePreviewOuterScroll = () => {
+        if (previewDevice !== 'pc') return;
+        const previewElement = previewOuterScrollRef.current;
+        const editorElement = editorScrollRef.current;
+        if (!previewElement || !editorElement) return;
+        syncScrollPosition(previewElement, editorElement, 'preview');
+    };
+
+    const handlePreviewInnerScroll = () => {
+        if (previewDevice === 'pc') return;
+        const previewElement = previewInnerScrollRef.current;
         const editorElement = editorScrollRef.current;
         if (!previewElement || !editorElement) return;
         syncScrollPosition(previewElement, editorElement, 'preview');
@@ -249,8 +272,10 @@ export default function App() {
                         deviceWidthClass={deviceWidthClass()}
                         previewDevice={previewDevice}
                         previewRef={previewRef}
-                        previewScrollRef={previewScrollRef}
-                        onPreviewScroll={handlePreviewScroll}
+                        previewOuterScrollRef={previewOuterScrollRef}
+                        previewInnerScrollRef={previewInnerScrollRef}
+                        onPreviewOuterScroll={handlePreviewOuterScroll}
+                        onPreviewInnerScroll={handlePreviewInnerScroll}
                         scrollSyncEnabled={scrollSyncEnabled}
                     />
                 </div>

--- a/src/components/DeviceFrame.tsx
+++ b/src/components/DeviceFrame.tsx
@@ -3,16 +3,22 @@ import React from 'react';
 interface DeviceFrameProps {
     device: 'mobile' | 'tablet';
     children: React.ReactNode;
+    scrollRef?: React.RefObject<HTMLDivElement>;
+    onScroll?: () => void;
 }
 
-export default function DeviceFrame({ device, children }: DeviceFrameProps) {
+export default function DeviceFrame({ device, children, scrollRef, onScroll }: DeviceFrameProps) {
     const isMobile = device === 'mobile';
     const frameClass = isMobile ? 'preview-device-mobile' : 'preview-device-tablet';
 
     return (
         <div className={`preview-device-shell ${frameClass}`}>
             <div className="preview-device-screen">
-                <div className="preview-device-scroll no-scrollbar">
+                <div
+                    ref={scrollRef}
+                    onScroll={onScroll}
+                    className="preview-device-scroll no-scrollbar"
+                >
                     {children}
                 </div>
             </div>

--- a/src/components/PreviewPanel.tsx
+++ b/src/components/PreviewPanel.tsx
@@ -6,23 +6,39 @@ interface PreviewPanelProps {
     deviceWidthClass: string;
     previewDevice: 'mobile' | 'tablet' | 'pc';
     previewRef: React.RefObject<HTMLDivElement>;
-    previewScrollRef: React.RefObject<HTMLDivElement>;
-    onPreviewScroll: () => void;
+    previewOuterScrollRef: React.RefObject<HTMLDivElement>;
+    previewInnerScrollRef: React.RefObject<HTMLDivElement>;
+    onPreviewOuterScroll: () => void;
+    onPreviewInnerScroll: () => void;
     scrollSyncEnabled: boolean;
 }
 
-export default function PreviewPanel({ renderedHtml, deviceWidthClass, previewDevice, previewRef, previewScrollRef, onPreviewScroll, scrollSyncEnabled }: PreviewPanelProps) {
+export default function PreviewPanel({
+    renderedHtml,
+    deviceWidthClass,
+    previewDevice,
+    previewRef,
+    previewOuterScrollRef,
+    previewInnerScrollRef,
+    onPreviewOuterScroll,
+    onPreviewInnerScroll,
+    scrollSyncEnabled
+}: PreviewPanelProps) {
     const isFramedDevice = previewDevice !== 'pc';
 
     return (
         <div
-            ref={previewScrollRef}
-            onScroll={scrollSyncEnabled ? onPreviewScroll : undefined}
+            ref={previewOuterScrollRef}
+            onScroll={scrollSyncEnabled && !isFramedDevice ? onPreviewOuterScroll : undefined}
             className="relative overflow-y-auto no-scrollbar bg-[#f2f2f7]/50 dark:bg-[#000000] flex flex-col z-20 flex-1 min-h-0 w-full overflow-x-hidden"
         >
             <div className={`${deviceWidthClass} transition-all duration-500 ${isFramedDevice ? 'self-center my-12 px-4 lg:px-8' : 'mt-12 mb-32 ml-4 md:ml-6 mr-auto'} h-fit min-h-[calc(100%-48px)] flex items-start justify-center relative`}>
                 {isFramedDevice ? (
-                    <DeviceFrame device={previewDevice as 'mobile' | 'tablet'}>
+                    <DeviceFrame
+                        device={previewDevice as 'mobile' | 'tablet'}
+                        scrollRef={previewInnerScrollRef}
+                        onScroll={scrollSyncEnabled ? onPreviewInnerScroll : undefined}
+                    >
                         <div
                             ref={previewRef}
                             dangerouslySetInnerHTML={{ __html: renderedHtml }}


### PR DESCRIPTION
## Summary
- bind preview scroll sync to the actual scrolling container per device mode
- keep desktop sync on the outer preview container
- wire mobile/tablet sync to the inner `.preview-device-scroll` container
- reset scroll-lock timeout when switching preview devices to avoid stale lock state

## Validation
- `npm run build`
- automated Playwright check for bidirectional sync ratios on PC/mobile/tablet:
  - editor -> preview: 0.2 => 0.2
  - preview -> editor: 0.8 => 0.8

Closes #3
