### PR TITLE
fix: right preview buttons are too far right on high-res screens

### DIFF
--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -15,7 +15,7 @@ interface ToolbarProps {
 
 export default function Toolbar({ previewDevice, onDeviceChange, onExportPdf, onExportHtml, onCopy, copied, isCopying, scrollSyncEnabled, onToggleScrollSync }: ToolbarProps) {
     return (
-        <div className="flex items-center justify-between px-4 sm:px-6 py-3">
+        <div className="flex items-center justify-between px-4 sm:px-6 py-3 max-w-[1024px]">
             <div className="hidden md:flex bg-[#00000008] dark:bg-[#ffffff10] p-1 rounded-full backdrop-blur-md">
                 <button
                     onClick={() => onDeviceChange('mobile')}


### PR DESCRIPTION
Restricting the max-width helps keep the buttons aligned with the content, improving the user experience on large monitors.
限制最大宽度有助于保持按钮与内容对齐，提升大显示器上的用户体验。

**Changes** 

CSS: Added max-width to the toolbar container.
CSS: 为工具栏容器添加了 max-width 属性。