### PR TITLE
feat: 编辑器新增本地图片上传按钮

### DIFF
--- a/src/components/EditorPanel.tsx
+++ b/src/components/EditorPanel.tsx
@@ -14,7 +14,7 @@ export default function EditorPanel({ markdownInput, onInputChange, editorScroll
     const fileInputRef = useRef<HTMLInputElement>(null);
 
     const onPaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
-        handleSmartPaste(e, markdownInput, onInputChange);
+        handleSmartPaste(e, onInputChange);
     };
 
     const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -31,7 +31,7 @@ export default function EditorPanel({ markdownInput, onInputChange, editorScroll
                     .map((src, index) => `![图片${files.length > 1 ? ` ${index + 1}` : ''}](${src})`)
                     .join('\n\n');
                 if (!markdownImages) return;
-                insertAtSelection(textarea, markdownInput, markdownImages, onInputChange);
+                insertAtSelection(textarea, markdownImages, onInputChange);
             })
             .catch((err) => {
                 console.error('Image upload failed:', err);

--- a/src/lib/htmlToMarkdown.ts
+++ b/src/lib/htmlToMarkdown.ts
@@ -101,13 +101,13 @@ export function fileToDataUrl(file: File): Promise<string> {
 
 export function insertAtSelection(
     textarea: HTMLTextAreaElement,
-    markdownInput: string,
     insertedText: string,
     setMarkdownInput: (val: string) => void
 ) {
+    const currentValue = textarea.value;
     const start = textarea.selectionStart;
     const end = textarea.selectionEnd;
-    const newValue = markdownInput.substring(0, start) + insertedText + markdownInput.substring(end);
+    const newValue = currentValue.substring(0, start) + insertedText + currentValue.substring(end);
     setMarkdownInput(newValue);
 
     setTimeout(() => {
@@ -119,7 +119,6 @@ export function insertAtSelection(
 
 export function handleSmartPaste(
     e: React.ClipboardEvent<HTMLTextAreaElement>,
-    markdownInput: string,
     setMarkdownInput: (val: string) => void
 ): void {
     const clipboardData = e.clipboardData;
@@ -141,7 +140,7 @@ export function handleSmartPaste(
                     .join('\n\n');
 
                 if (!markdownImages) return;
-                insertAtSelection(textarea, markdownInput, markdownImages, setMarkdownInput);
+                insertAtSelection(textarea, markdownImages, setMarkdownInput);
             })
             .catch((err) => {
                 console.error('Clipboard image conversion failed:', err);
@@ -180,12 +179,12 @@ export function handleSmartPaste(
             markdown = markdown.replace(/\n{3,}/g, '\n\n');
 
             const textarea = e.currentTarget;
-            insertAtSelection(textarea, markdownInput, markdown, setMarkdownInput);
+            insertAtSelection(textarea, markdown, setMarkdownInput);
         } catch (err) {
             console.error('HTML to Markdown conversion failed:', err);
             // Fallback to text
             const textarea = e.currentTarget;
-            insertAtSelection(textarea, markdownInput, textData, setMarkdownInput);
+            insertAtSelection(textarea, textData, setMarkdownInput);
         }
     } else if (textData && isMarkdown(textData)) {
         return;


### PR DESCRIPTION
  ## 问题

对于不熟悉技术的用户，并不知道可以直接从剪贴板粘贴图片、自动转为 Base64 内嵌。没有可见的上传入口，用户往往找不到插入图片的方法，造成不必要的使用困惑。

  ## 解决方案
- 在编辑器底部操作栏新增「插入图片」按钮
- 点击调起系统文件选择器，支持单张或多张图片
- 图片自动转为 Base64 内嵌，以 Markdown 语法插入到光标位置
- 导出 fileToDataUrl 和 insertAtSelection 供复用
- 原有剪贴板粘贴图片功能保持不变


  ## 改动文件

  - `src/lib/htmlToMarkdown.ts` — 导出 `fileToDataUrl` 和 `insertAtSelection` 供复用
  - `src/components/EditorPanel.tsx` — 新增图片上传按钮和文件处理逻辑