### PR TITLE
fix: preserve full data URLs in pasted HTML images

### DIFF
--- a/src/lib/htmlToMarkdown.ts
+++ b/src/lib/htmlToMarkdown.ts
@@ -19,14 +19,13 @@ turndownService.addRule('image', {
     filter: 'img',
     replacement: (_content, node: any) => {
         const alt = node.alt || '图片';
-        const src = node.src || '';
-        const title = node.title || '';
-        if (src.startsWith('data:image')) {
-            const typeMatch = src.match(/data:image\/(\w+);/);
-            const type = typeMatch ? typeMatch[1] : 'image';
-            return `![${alt}](data:image/${type};base64,...)${title ? ` "${title}"` : ''}\n`;
-        }
-        return `![${alt}](${src})${title ? ` "${title}"` : ''}\n`;
+        const src = (node.getAttribute?.('src') || node.src || '').trim();
+        const title = (node.title || '').replace(/"/g, '\\"');
+
+        if (!src) return '';
+
+        // Preserve full data URLs. Truncating them produces broken pasted images.
+        return `![${alt}](${src}${title ? ` "${title}"` : ''})\n`;
     }
 });
 


### PR DESCRIPTION
Fixes #12

## Problem
When pasting HTML content containing inline images with `data:` URLs (e.g., copied from a browser), the images were converted to broken Markdown links like:

```
![图片](data:image/png;base64,...)
```

This made the images unrenderable.

## Root Cause
The custom Turndown `image` rule in `src/lib/htmlToMarkdown.ts` was deliberately truncating `data:image` URLs by replacing the base64 payload with `...`.

## Fix
1. **Preserve full data URLs** - Remove the truncation logic, keep the complete base64 payload
2. **Fix image title syntax** - Changed from `![alt](src) "title"` (invalid) to `![alt](src "title")` (valid Markdown)
3. **Use getAttribute first** - Prefer `getAttribute('src')` to preserve the literal HTML attribute value

## Testing
1. Copy an image from a web page (with inline data URL)
2. Paste into the editor
3. Verify the Markdown contains the full data URL
4. Verify the preview renders the image correctly