### PR TITLE
[codex] add right preview drawer for faster browsing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ export default function App() {
     const [isCopying, setIsCopying] = useState(false);
     const [previewDevice, setPreviewDevice] = useState<'mobile' | 'tablet' | 'pc'>('pc');
     const [activePanel, setActivePanel] = useState<'editor' | 'preview'>('editor');
-    const [desktopPreviewMode, setDesktopPreviewMode] = useState<'split' | 'drawer'>('drawer');
+    const [desktopPreviewMode, setDesktopPreviewMode] = useState<'split' | 'drawer'>('split');
     const [desktopPreviewOpen, setDesktopPreviewOpen] = useState(true);
     const [scrollSyncEnabled, setScrollSyncEnabled] = useState(true);
     const previewRef = useRef<HTMLDivElement>(null);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -281,19 +281,21 @@ export default function App() {
                         scrollSyncEnabled={scrollSyncEnabled}
                     />
                 </div>
-                <div className={`${activePanel === 'preview' ? 'flex' : 'hidden'} ${desktopPreviewMode === 'split' ? 'md:flex' : 'md:hidden'} flex-col overflow-hidden`}>
-                    <PreviewPanel
-                        renderedHtml={renderedHtml}
-                        deviceWidthClass={deviceWidthClass()}
-                        previewDevice={previewDevice}
-                        previewRef={previewRef}
-                        previewOuterScrollRef={previewOuterScrollRef}
-                        previewInnerScrollRef={previewInnerScrollRef}
-                        onPreviewOuterScroll={handlePreviewOuterScroll}
-                        onPreviewInnerScroll={handlePreviewInnerScroll}
-                        scrollSyncEnabled={scrollSyncEnabled}
-                    />
-                </div>
+                {(activePanel === 'preview' || desktopPreviewMode === 'split') && (
+                    <div className={`${activePanel === 'preview' ? 'flex' : 'hidden'} ${desktopPreviewMode === 'split' ? 'md:flex' : 'md:hidden'} flex-col overflow-hidden`}>
+                        <PreviewPanel
+                            renderedHtml={renderedHtml}
+                            deviceWidthClass={deviceWidthClass()}
+                            previewDevice={previewDevice}
+                            previewRef={previewRef}
+                            previewOuterScrollRef={previewOuterScrollRef}
+                            previewInnerScrollRef={previewInnerScrollRef}
+                            onPreviewOuterScroll={handlePreviewOuterScroll}
+                            onPreviewInnerScroll={handlePreviewInnerScroll}
+                            scrollSyncEnabled={scrollSyncEnabled}
+                        />
+                    </div>
+                )}
 
                 {desktopPreviewMode === 'drawer' && (
                     <div

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,8 @@ export default function App() {
     const [isCopying, setIsCopying] = useState(false);
     const [previewDevice, setPreviewDevice] = useState<'mobile' | 'tablet' | 'pc'>('pc');
     const [activePanel, setActivePanel] = useState<'editor' | 'preview'>('editor');
+    const [desktopPreviewMode, setDesktopPreviewMode] = useState<'split' | 'drawer'>('drawer');
+    const [desktopPreviewOpen, setDesktopPreviewOpen] = useState(true);
     const [scrollSyncEnabled, setScrollSyncEnabled] = useState(true);
     const previewRef = useRef<HTMLDivElement>(null);
     const editorScrollRef = useRef<HTMLTextAreaElement>(null);
@@ -195,6 +197,7 @@ export default function App() {
     };
 
     const gridLayoutClass = () => {
+        if (desktopPreviewMode === 'drawer') return 'md:grid-cols-1';
         if (previewDevice === 'mobile') return 'md:grid-cols-[55fr_45fr]';
         if (previewDevice === 'tablet') return 'md:grid-cols-[45fr_55fr]';
         return 'md:grid-cols-[38.2fr_61.8fr]';
@@ -230,7 +233,11 @@ export default function App() {
                 <ThemeSelector activeTheme={activeTheme} onThemeChange={setActiveTheme} />
                 <Toolbar
                     previewDevice={previewDevice}
+                    desktopPreviewMode={desktopPreviewMode}
+                    desktopPreviewOpen={desktopPreviewOpen}
                     onDeviceChange={setPreviewDevice}
+                    onDesktopPreviewModeChange={setDesktopPreviewMode}
+                    onToggleDesktopPreview={() => setDesktopPreviewOpen((prev) => !prev)}
                     onExportPdf={handleExportPdf}
                     onExportHtml={handleExportHtml}
                     onCopy={handleCopy}
@@ -248,7 +255,11 @@ export default function App() {
                 </div>
                 <Toolbar
                     previewDevice={previewDevice}
+                    desktopPreviewMode={desktopPreviewMode}
+                    desktopPreviewOpen={desktopPreviewOpen}
                     onDeviceChange={setPreviewDevice}
+                    onDesktopPreviewModeChange={setDesktopPreviewMode}
+                    onToggleDesktopPreview={() => setDesktopPreviewOpen((prev) => !prev)}
                     onExportPdf={handleExportPdf}
                     onExportHtml={handleExportHtml}
                     onCopy={handleCopy}
@@ -270,7 +281,7 @@ export default function App() {
                         scrollSyncEnabled={scrollSyncEnabled}
                     />
                 </div>
-                <div className={`${activePanel === 'preview' ? 'flex' : 'hidden'} md:flex flex-col overflow-hidden`}>
+                <div className={`${activePanel === 'preview' ? 'flex' : 'hidden'} ${desktopPreviewMode === 'split' ? 'md:flex' : 'md:hidden'} flex-col overflow-hidden`}>
                     <PreviewPanel
                         renderedHtml={renderedHtml}
                         deviceWidthClass={deviceWidthClass()}
@@ -283,6 +294,43 @@ export default function App() {
                         scrollSyncEnabled={scrollSyncEnabled}
                     />
                 </div>
+
+                {desktopPreviewMode === 'drawer' && (
+                    <div
+                        className={`hidden md:flex absolute inset-y-0 right-0 z-40 pointer-events-none transition-transform duration-300 ease-out ${desktopPreviewOpen ? 'translate-x-0' : 'translate-x-[calc(100%-44px)]'}`}
+                    >
+                        <div className="pointer-events-auto flex items-center">
+                            <button
+                                type="button"
+                                data-testid="desktop-drawer-edge-toggle"
+                                onClick={() => setDesktopPreviewOpen((prev) => !prev)}
+                                className="h-28 w-11 rounded-l-2xl border border-r-0 border-[#00000010] bg-white/92 text-[#3a4a69] shadow-[0_12px_30px_rgba(15,23,42,0.16)] backdrop-blur-xl transition hover:text-[#0066cc] dark:border-[#ffffff15] dark:bg-[#1c1c1e]/92 dark:text-[#d2d2d7] dark:hover:text-[#0a84ff]"
+                                aria-label={desktopPreviewOpen ? '收起右侧预览窗' : '展开右侧预览窗'}
+                            >
+                                <div className="flex h-full flex-col items-center justify-center gap-2">
+                                    <Eye size={16} />
+                                    <span className="[writing-mode:vertical-rl] text-[11px] font-semibold tracking-[0.18em]">
+                                        预览
+                                    </span>
+                                </div>
+                            </button>
+                        </div>
+
+                        <div className="pointer-events-auto h-full w-[min(44vw,760px)] max-w-[92vw] border-l border-[#00000010] bg-white/82 shadow-[-24px_0_60px_rgba(15,23,42,0.14)] backdrop-blur-2xl dark:border-[#ffffff10] dark:bg-[#0b0b0d]/88">
+                            <PreviewPanel
+                                renderedHtml={renderedHtml}
+                                deviceWidthClass={deviceWidthClass()}
+                                previewDevice={previewDevice}
+                                previewRef={previewRef}
+                                previewOuterScrollRef={previewOuterScrollRef}
+                                previewInnerScrollRef={previewInnerScrollRef}
+                                onPreviewOuterScroll={handlePreviewOuterScroll}
+                                onPreviewInnerScroll={handlePreviewInnerScroll}
+                                scrollSyncEnabled={scrollSyncEnabled}
+                            />
+                        </div>
+                    </div>
+                )}
             </main>
 
         </div>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -35,32 +35,34 @@ export default function Toolbar({
     return (
         <div className="flex items-center justify-between gap-4 px-4 sm:px-6 py-3 max-w-[1024px]">
             <div className="hidden md:flex items-center gap-3">
-                <div className="flex bg-[#00000008] dark:bg-[#ffffff10] p-1 rounded-full backdrop-blur-md">
-                    <button
-                        data-testid="device-mobile"
-                        onClick={() => onDeviceChange('mobile')}
-                        className={`p-2 rounded-full transition-all ${previewDevice === 'mobile' ? 'bg-white dark:bg-[#2c2c2e] shadow-sm' : 'text-[#86868b] dark:text-[#a1a1a6] hover:text-[#1d1d1f] dark:hover:text-[#f5f5f7]'}`}
-                        title="手机视图 (480px)"
-                    >
-                        <Smartphone size={16} />
-                    </button>
-                    <button
-                        data-testid="device-tablet"
-                        onClick={() => onDeviceChange('tablet')}
-                        className={`p-2 rounded-full transition-all ${previewDevice === 'tablet' ? 'bg-white dark:bg-[#2c2c2e] shadow-sm' : 'text-[#86868b] dark:text-[#a1a1a6] hover:text-[#1d1d1f] dark:hover:text-[#f5f5f7]'}`}
-                        title="平板视图 (768px)"
-                    >
-                        <Tablet size={16} />
-                    </button>
-                    <button
-                        data-testid="device-pc"
-                        onClick={() => onDeviceChange('pc')}
-                        className={`p-2 rounded-full transition-all ${previewDevice === 'pc' ? 'bg-white dark:bg-[#2c2c2e] shadow-sm' : 'text-[#86868b] dark:text-[#a1a1a6] hover:text-[#1d1d1f] dark:hover:text-[#f5f5f7]'}`}
-                        title="桌面视图 (PC)"
-                    >
-                        <Monitor size={16} />
-                    </button>
-                </div>
+                {desktopPreviewMode === 'split' && (
+                    <div className="flex bg-[#00000008] dark:bg-[#ffffff10] p-1 rounded-full backdrop-blur-md">
+                        <button
+                            data-testid="device-mobile"
+                            onClick={() => onDeviceChange('mobile')}
+                            className={`p-2 rounded-full transition-all ${previewDevice === 'mobile' ? 'bg-white dark:bg-[#2c2c2e] shadow-sm' : 'text-[#86868b] dark:text-[#a1a1a6] hover:text-[#1d1d1f] dark:hover:text-[#f5f5f7]'}`}
+                            title="手机视图 (480px)"
+                        >
+                            <Smartphone size={16} />
+                        </button>
+                        <button
+                            data-testid="device-tablet"
+                            onClick={() => onDeviceChange('tablet')}
+                            className={`p-2 rounded-full transition-all ${previewDevice === 'tablet' ? 'bg-white dark:bg-[#2c2c2e] shadow-sm' : 'text-[#86868b] dark:text-[#a1a1a6] hover:text-[#1d1d1f] dark:hover:text-[#f5f5f7]'}`}
+                            title="平板视图 (768px)"
+                        >
+                            <Tablet size={16} />
+                        </button>
+                        <button
+                            data-testid="device-pc"
+                            onClick={() => onDeviceChange('pc')}
+                            className={`p-2 rounded-full transition-all ${previewDevice === 'pc' ? 'bg-white dark:bg-[#2c2c2e] shadow-sm' : 'text-[#86868b] dark:text-[#a1a1a6] hover:text-[#1d1d1f] dark:hover:text-[#f5f5f7]'}`}
+                            title="桌面视图 (PC)"
+                        >
+                            <Monitor size={16} />
+                        </button>
+                    </div>
+                )}
 
                 <div className="flex bg-[#00000008] dark:bg-[#ffffff10] p-1 rounded-full backdrop-blur-md">
                     <button

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,9 +1,13 @@
-import { Copy, CheckCircle2, Download, Smartphone, Tablet, Monitor, Loader2, Link2, Unlink2 } from 'lucide-react';
+import { Copy, CheckCircle2, Download, Smartphone, Tablet, Monitor, Loader2, Link2, Unlink2, Columns2, PanelRightOpen, PanelRightClose } from 'lucide-react';
 import { motion } from 'framer-motion';
 
 interface ToolbarProps {
     previewDevice: 'mobile' | 'tablet' | 'pc';
+    desktopPreviewMode: 'split' | 'drawer';
+    desktopPreviewOpen: boolean;
     onDeviceChange: (device: 'mobile' | 'tablet' | 'pc') => void;
+    onDesktopPreviewModeChange: (mode: 'split' | 'drawer') => void;
+    onToggleDesktopPreview: () => void;
     onExportPdf: () => void;
     onExportHtml: () => void;
     onCopy: () => void;
@@ -13,34 +17,83 @@ interface ToolbarProps {
     onToggleScrollSync: () => void;
 }
 
-export default function Toolbar({ previewDevice, onDeviceChange, onExportPdf, onExportHtml, onCopy, copied, isCopying, scrollSyncEnabled, onToggleScrollSync }: ToolbarProps) {
+export default function Toolbar({
+    previewDevice,
+    desktopPreviewMode,
+    desktopPreviewOpen,
+    onDeviceChange,
+    onDesktopPreviewModeChange,
+    onToggleDesktopPreview,
+    onExportPdf,
+    onExportHtml,
+    onCopy,
+    copied,
+    isCopying,
+    scrollSyncEnabled,
+    onToggleScrollSync
+}: ToolbarProps) {
     return (
-        <div className="flex items-center justify-between px-4 sm:px-6 py-3 max-w-[1024px]">
-            <div className="hidden md:flex bg-[#00000008] dark:bg-[#ffffff10] p-1 rounded-full backdrop-blur-md">
-                <button
-                    data-testid="device-mobile"
-                    onClick={() => onDeviceChange('mobile')}
-                    className={`p-2 rounded-full transition-all ${previewDevice === 'mobile' ? 'bg-white dark:bg-[#2c2c2e] shadow-sm' : 'text-[#86868b] dark:text-[#a1a1a6] hover:text-[#1d1d1f] dark:hover:text-[#f5f5f7]'}`}
-                    title="手机视图 (480px)"
-                >
-                    <Smartphone size={16} />
-                </button>
-                <button
-                    data-testid="device-tablet"
-                    onClick={() => onDeviceChange('tablet')}
-                    className={`p-2 rounded-full transition-all ${previewDevice === 'tablet' ? 'bg-white dark:bg-[#2c2c2e] shadow-sm' : 'text-[#86868b] dark:text-[#a1a1a6] hover:text-[#1d1d1f] dark:hover:text-[#f5f5f7]'}`}
-                    title="平板视图 (768px)"
-                >
-                    <Tablet size={16} />
-                </button>
-                <button
-                    data-testid="device-pc"
-                    onClick={() => onDeviceChange('pc')}
-                    className={`p-2 rounded-full transition-all ${previewDevice === 'pc' ? 'bg-white dark:bg-[#2c2c2e] shadow-sm' : 'text-[#86868b] dark:text-[#a1a1a6] hover:text-[#1d1d1f] dark:hover:text-[#f5f5f7]'}`}
-                    title="桌面视图 (PC)"
-                >
-                    <Monitor size={16} />
-                </button>
+        <div className="flex items-center justify-between gap-4 px-4 sm:px-6 py-3 max-w-[1024px]">
+            <div className="hidden md:flex items-center gap-3">
+                <div className="flex bg-[#00000008] dark:bg-[#ffffff10] p-1 rounded-full backdrop-blur-md">
+                    <button
+                        data-testid="device-mobile"
+                        onClick={() => onDeviceChange('mobile')}
+                        className={`p-2 rounded-full transition-all ${previewDevice === 'mobile' ? 'bg-white dark:bg-[#2c2c2e] shadow-sm' : 'text-[#86868b] dark:text-[#a1a1a6] hover:text-[#1d1d1f] dark:hover:text-[#f5f5f7]'}`}
+                        title="手机视图 (480px)"
+                    >
+                        <Smartphone size={16} />
+                    </button>
+                    <button
+                        data-testid="device-tablet"
+                        onClick={() => onDeviceChange('tablet')}
+                        className={`p-2 rounded-full transition-all ${previewDevice === 'tablet' ? 'bg-white dark:bg-[#2c2c2e] shadow-sm' : 'text-[#86868b] dark:text-[#a1a1a6] hover:text-[#1d1d1f] dark:hover:text-[#f5f5f7]'}`}
+                        title="平板视图 (768px)"
+                    >
+                        <Tablet size={16} />
+                    </button>
+                    <button
+                        data-testid="device-pc"
+                        onClick={() => onDeviceChange('pc')}
+                        className={`p-2 rounded-full transition-all ${previewDevice === 'pc' ? 'bg-white dark:bg-[#2c2c2e] shadow-sm' : 'text-[#86868b] dark:text-[#a1a1a6] hover:text-[#1d1d1f] dark:hover:text-[#f5f5f7]'}`}
+                        title="桌面视图 (PC)"
+                    >
+                        <Monitor size={16} />
+                    </button>
+                </div>
+
+                <div className="flex bg-[#00000008] dark:bg-[#ffffff10] p-1 rounded-full backdrop-blur-md">
+                    <button
+                        data-testid="desktop-layout-split"
+                        onClick={() => onDesktopPreviewModeChange('split')}
+                        className={`p-2 rounded-full transition-all ${desktopPreviewMode === 'split' ? 'bg-white dark:bg-[#2c2c2e] shadow-sm text-[#1d1d1f] dark:text-[#f5f5f7]' : 'text-[#86868b] dark:text-[#a1a1a6] hover:text-[#1d1d1f] dark:hover:text-[#f5f5f7]'}`}
+                        title="分栏预览"
+                    >
+                        <Columns2 size={16} />
+                    </button>
+                    <button
+                        data-testid="desktop-layout-drawer"
+                        onClick={() => onDesktopPreviewModeChange('drawer')}
+                        className={`p-2 rounded-full transition-all ${desktopPreviewMode === 'drawer' ? 'bg-white dark:bg-[#2c2c2e] shadow-sm text-[#1d1d1f] dark:text-[#f5f5f7]' : 'text-[#86868b] dark:text-[#a1a1a6] hover:text-[#1d1d1f] dark:hover:text-[#f5f5f7]'}`}
+                        title="右侧滑动窗预览"
+                    >
+                        <PanelRightOpen size={16} />
+                    </button>
+                </div>
+
+                {desktopPreviewMode === 'drawer' && (
+                    <motion.button
+                        whileHover={{ scale: 1.02 }}
+                        whileTap={{ scale: 0.96 }}
+                        data-testid="desktop-drawer-toggle"
+                        onClick={onToggleDesktopPreview}
+                        className="apple-export-btn !bg-[#00000008] dark:!bg-[#ffffff10] border-transparent text-[#1d1d1f] dark:text-[#f5f5f7]"
+                        title={desktopPreviewOpen ? '收起右侧预览窗' : '展开右侧预览窗'}
+                    >
+                        {desktopPreviewOpen ? <PanelRightClose size={14} /> : <PanelRightOpen size={14} />}
+                        <span>{desktopPreviewOpen ? '收起预览' : '展开预览'}</span>
+                    </motion.button>
+                )}
             </div>
 
             <div className="flex items-center gap-4">


### PR DESCRIPTION
## Summary

This change adds a desktop-friendly right-side preview drawer so readers can browse rendered output more quickly without permanently giving up editor width. The toolbar now lets users switch between the existing split layout and a new drawer layout, and the drawer can be collapsed or reopened from both the toolbar and a persistent edge handle.

## Why

The current split view works, but it forces the preview to occupy a large portion of the screen all the time. That is fine for longer editing sessions, but it is less efficient when someone mainly wants to scan the rendered result, compare sections quickly, and then return focus to writing. A slide-out preview keeps that fast inspection path available without locking the workspace into a two-column layout.

## What changed

On desktop, users can now choose between `split` and `drawer` preview modes from the toolbar. In drawer mode, the editor uses the full main canvas width while the preview lives in a right-side sliding panel. The preview panel can be toggled open and closed from the toolbar, and it also exposes a visible edge control so it can be reopened quickly after being collapsed.

The existing mobile and tablet preview controls stay intact, and the preview drawer reuses the same preview rendering pipeline and scroll-sync behavior as the split layout.

## Validation

I validated the change with:

- `XDG_CACHE_HOME=/tmp/luochen-cache pnpm build`
- `XDG_CACHE_HOME=/tmp/luochen-cache pnpm test`
