### PR TITLE
[codex] render base64 image markdown

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -123,6 +123,20 @@ test('renders base64 image markdown without leaking data url text', async ({ pag
     await expect(preview).not.toContainText('data:image/png;base64');
 });
 
+test('repairs split base64 image markdown without leaking data url text', async ({ page }) => {
+    await gotoApp(page);
+
+    const dataUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+    const editor = page.getByTestId('editor-input');
+    await editor.fill(`# 标题\n\n![图片]\n(${dataUrl})\n\n正文`);
+
+    const preview = page.getByTestId('preview-content');
+    const image = preview.locator('img');
+
+    await expect(image).toHaveAttribute('src', dataUrl);
+    await expect(preview).not.toContainText('data:image/png;base64');
+});
+
 for (const device of [
     { testId: 'device-mobile', label: 'mobile' },
     { testId: 'device-tablet', label: 'tablet' }

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -137,6 +137,31 @@ test('repairs split base64 image markdown without leaking data url text', async 
     await expect(preview).not.toContainText('data:image/png;base64');
 });
 
+test('compacts pasted base64 image markdown in the editor', async ({ page }) => {
+    await gotoApp(page);
+
+    const dataUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+    const editor = page.getByTestId('editor-input');
+    await editor.focus();
+    await page.evaluate((text) => {
+        const textarea = document.querySelector('[data-testid="editor-input"]') as HTMLTextAreaElement;
+        const dataTransfer = new DataTransfer();
+        dataTransfer.setData('text/plain', text);
+        const event = new ClipboardEvent('paste', {
+            clipboardData: dataTransfer,
+            bubbles: true,
+            cancelable: true
+        });
+        textarea.dispatchEvent(event);
+    }, `![图片]\n(${dataUrl})`);
+
+    await expect(editor).toHaveValue(/!\[图片\]\(blob:/);
+    await expect(editor).not.toHaveValue(/data:image\/png;base64/);
+
+    const preview = page.getByTestId('preview-content');
+    await expect(preview.locator('img').first()).toHaveAttribute('src', /blob:/);
+});
+
 for (const device of [
     { testId: 'device-mobile', label: 'mobile' },
     { testId: 'device-tablet', label: 'tablet' }

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -21,6 +21,10 @@ async function waitForScrollableArea(page: import('@playwright/test').Page, test
         .toBeGreaterThan(200);
 }
 
+async function gotoApp(page: import('@playwright/test').Page) {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+}
+
 async function setScrollRatio(page: import('@playwright/test').Page, testId: string, ratio: number) {
     await page.evaluate(
         ([id, nextRatio]) => {
@@ -80,7 +84,7 @@ async function scrollAndWaitForSync(
 
 test('keeps the copy button visible on mobile', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
-    await page.goto('/');
+    await gotoApp(page);
 
     await page.getByTestId('tab-preview').click();
     const copyButton = page.locator('[data-testid="copy-button"]:visible');
@@ -94,7 +98,7 @@ test('keeps the copy button visible on mobile', async ({ page }) => {
 });
 
 test('renders bold text with punctuation without leaking markdown markers', async ({ page }) => {
-    await page.goto('/');
+    await gotoApp(page);
 
     const editor = page.getByTestId('editor-input');
     await editor.fill('2025年初，伦敦黄金市场的一个月拆借利率一度升至**5%**。');
@@ -105,13 +109,27 @@ test('renders bold text with punctuation without leaking markdown markers', asyn
     await expect(preview).toContainText('2025年初，伦敦黄金市场的一个月拆借利率一度升至5%。');
 });
 
+test('renders base64 image markdown without leaking data url text', async ({ page }) => {
+    await gotoApp(page);
+
+    const dataUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+    const editor = page.getByTestId('editor-input');
+    await editor.fill(`# 标题\n\n![图片](${dataUrl})\n\n正文`);
+
+    const preview = page.getByTestId('preview-content');
+    const image = preview.locator('img');
+
+    await expect(image).toHaveAttribute('src', dataUrl);
+    await expect(preview).not.toContainText('data:image/png;base64');
+});
+
 for (const device of [
     { testId: 'device-mobile', label: 'mobile' },
     { testId: 'device-tablet', label: 'tablet' }
 ] as const) {
     test(`syncs editor and ${device.label} preview scrolling in both directions`, async ({ page }) => {
         await page.setViewportSize({ width: 1440, height: 900 });
-        await page.goto('/');
+        await gotoApp(page);
 
         const editor = page.getByTestId('editor-input');
         await editor.fill(buildLongMarkdown());

--- a/src/lib/htmlToMarkdown.test.ts
+++ b/src/lib/htmlToMarkdown.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { insertAtSelection } from './htmlToMarkdown';
+import { compactDataImageMarkdown, insertAtSelection } from './htmlToMarkdown';
 
 describe('insertAtSelection', () => {
     beforeEach(() => {
@@ -49,5 +49,29 @@ describe('insertAtSelection', () => {
 
         expect(textarea.selectionStart).toBe('hello Raphael'.length);
         expect(textarea.selectionEnd).toBe('hello Raphael'.length);
+    });
+});
+
+describe('compactDataImageMarkdown', () => {
+    const createObjectUrl = URL.createObjectURL;
+
+    beforeEach(() => {
+        URL.createObjectURL = vi.fn(() => 'blob:http://localhost/image-1');
+    });
+
+    afterEach(() => {
+        URL.createObjectURL = createObjectUrl;
+    });
+
+    it('replaces inline data image markdown with a blob url', () => {
+        const markdown = '![图片](data:image/png;base64,AAAA)';
+
+        expect(compactDataImageMarkdown(markdown)).toBe('![图片](blob:http://localhost/image-1)');
+    });
+
+    it('replaces split data image markdown with a blob url', () => {
+        const markdown = '![图片]\n(data:image/png;base64,AAAA)';
+
+        expect(compactDataImageMarkdown(markdown)).toBe('![图片](blob:http://localhost/image-1)');
     });
 });

--- a/src/lib/htmlToMarkdown.ts
+++ b/src/lib/htmlToMarkdown.ts
@@ -98,6 +98,44 @@ function fileToDataUrl(file: File): Promise<string> {
     });
 }
 
+const dataImageMarkdownPattern = /!\[([^\]\n]*)\]\((data:image\/(?:png|jpe?g|gif|webp|bmp);base64,[^)]+)\)/gi;
+const splitDataImageMarkdownPattern = /!\[([^\]\n]*)\][ \t]*(?:\r?\n[ \t]*)+\((data:image\/(?:png|jpe?g|gif|webp|bmp);base64,[^)]+)\)/gi;
+
+function hasDataImageMarkdown(markdown: string): boolean {
+    dataImageMarkdownPattern.lastIndex = 0;
+    splitDataImageMarkdownPattern.lastIndex = 0;
+    return dataImageMarkdownPattern.test(markdown) || splitDataImageMarkdownPattern.test(markdown);
+}
+
+function dataUrlToObjectUrl(dataUrl: string): string {
+    const cleanDataUrl = dataUrl.replace(/\s+/g, '');
+    const [metadata, data] = cleanDataUrl.split(',');
+    const mime = metadata.match(/^data:([^;]+);base64$/i)?.[1] || 'image/png';
+    const binary = atob(data);
+    const bytes = new Uint8Array(binary.length);
+
+    for (let i = 0; i < binary.length; i += 1) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+
+    return URL.createObjectURL(new Blob([bytes], { type: mime }));
+}
+
+export function compactDataImageMarkdown(markdown: string): string {
+    const compact = (_match: string, alt: string, src: string) => {
+        try {
+            return `![${alt || '图片'}](${dataUrlToObjectUrl(src)})`;
+        } catch (err) {
+            console.error('Data image compaction failed:', err);
+            return `![${alt || '图片'}](${String(src).replace(/\s+/g, '')})`;
+        }
+    };
+
+    return markdown
+        .replace(splitDataImageMarkdownPattern, compact)
+        .replace(dataImageMarkdownPattern, compact);
+}
+
 export function insertAtSelection(
     textarea: HTMLTextAreaElement,
     insertedText: string,
@@ -135,7 +173,10 @@ export function handleSmartPaste(
             .then((dataUrls) => {
                 const markdownImages = dataUrls
                     .filter(Boolean)
-                    .map((src, index) => `![图片${dataUrls.length > 1 ? ` ${index + 1}` : ''}](${src})`)
+                    .map((src, index) => {
+                        const displaySrc = dataUrlToObjectUrl(src);
+                        return `![图片${dataUrls.length > 1 ? ` ${index + 1}` : ''}](${displaySrc})`;
+                    })
                     .join('\n\n');
 
                 if (!markdownImages) return;
@@ -150,6 +191,13 @@ export function handleSmartPaste(
 
     if (textData && /^\[Image\s*#?\d*\]$/i.test(textData.trim())) {
         e.preventDefault();
+        return;
+    }
+
+    if (textData && hasDataImageMarkdown(textData)) {
+        e.preventDefault();
+        const textarea = e.currentTarget;
+        insertAtSelection(textarea, compactDataImageMarkdown(textData), setMarkdownInput);
         return;
     }
 
@@ -176,6 +224,7 @@ export function handleSmartPaste(
         try {
             let markdown = turndownService.turndown(htmlData);
             markdown = markdown.replace(/\n{3,}/g, '\n\n');
+            markdown = compactDataImageMarkdown(markdown);
 
             const textarea = e.currentTarget;
             insertAtSelection(textarea, markdown, setMarkdownInput);
@@ -186,6 +235,12 @@ export function handleSmartPaste(
             insertAtSelection(textarea, textData, setMarkdownInput);
         }
     } else if (textData && isMarkdown(textData)) {
+        const compactedMarkdown = compactDataImageMarkdown(textData);
+        if (compactedMarkdown !== textData) {
+            e.preventDefault();
+            const textarea = e.currentTarget;
+            insertAtSelection(textarea, compactedMarkdown, setMarkdownInput);
+        }
         return;
     }
 }

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -29,6 +29,24 @@ describe('preprocessMarkdown', () => {
     });
 });
 
+describe('markdown image rendering', () => {
+    it('renders pasted base64 image markdown as an image', () => {
+        const dataUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+        const html = renderMarkdown(`![图片](${dataUrl})`);
+        const doc = new DOMParser().parseFromString(html, 'text/html');
+        const image = doc.querySelector('img');
+
+        expect(image?.getAttribute('src')).toBe(dataUrl);
+        expect(doc.body.textContent).not.toContain('base64');
+    });
+
+    it('does not allow arbitrary data urls', () => {
+        const html = renderMarkdown('![图片](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)');
+
+        expect(html).not.toContain('<img');
+    });
+});
+
 describe('applyTheme', () => {
     it('groups consecutive standalone images into an image grid', () => {
         const html = '<p><img src="a.png" /></p><p><img src="b.png" /></p>';

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -27,6 +27,27 @@ describe('preprocessMarkdown', () => {
 
         expect(doc.querySelectorAll('strong')).toHaveLength(2);
     });
+
+    it('repairs data image markdown split across adjacent lines', () => {
+        const dataUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+        const html = renderMarkdown(`![图片]\n(${dataUrl})`);
+        const doc = new DOMParser().parseFromString(html, 'text/html');
+        const image = doc.querySelector('img');
+
+        expect(image?.getAttribute('src')).toBe(dataUrl);
+        expect(doc.body.textContent).not.toContain('data:image/png;base64');
+    });
+
+    it('repairs wrapped whitespace inside data image urls', () => {
+        const wrapped = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8\nAAwMCAO+/p9sAAAAASUVORK5CYII=';
+        const expected = wrapped.replace(/\s+/g, '');
+        const html = renderMarkdown(`![图片]\n(${wrapped})`);
+        const doc = new DOMParser().parseFromString(html, 'text/html');
+        const image = doc.querySelector('img');
+
+        expect(image?.getAttribute('src')).toBe(expected);
+        expect(doc.body.textContent).not.toContain('base64');
+    });
 });
 
 describe('markdown image rendering', () => {

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -38,6 +38,16 @@ describe('preprocessMarkdown', () => {
         expect(doc.body.textContent).not.toContain('data:image/png;base64');
     });
 
+    it('repairs data image markdown split by blank lines', () => {
+        const dataUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+        const html = renderMarkdown(`![图片]\n\n   \n(${dataUrl})`);
+        const doc = new DOMParser().parseFromString(html, 'text/html');
+        const image = doc.querySelector('img');
+
+        expect(image?.getAttribute('src')).toBe(dataUrl);
+        expect(doc.body.textContent).not.toContain('data:image/png;base64');
+    });
+
     it('repairs wrapped whitespace inside data image urls', () => {
         const wrapped = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8\nAAwMCAO+/p9sAAAAASUVORK5CYII=';
         const expected = wrapped.replace(/\s+/g, '');

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -27,6 +27,7 @@ export const md = new MarkdownIt({
 
 const defaultValidateLink = md.validateLink.bind(md);
 const safeDataImagePattern = /^data:image\/(?:png|jpe?g|gif|webp|bmp);base64,[a-z0-9+/=\s]+$/i;
+const dataImageUrlPattern = /data:image\/(?:png|jpe?g|gif|webp|bmp);base64,[^)]+/gi;
 
 md.validateLink = (url: string) => {
     return defaultValidateLink(url) || safeDataImagePattern.test(url);
@@ -34,6 +35,15 @@ md.validateLink = (url: string) => {
 
 // Avoid bold fragmentation when pasting from certain apps
 export function preprocessMarkdown(content: string) {
+    // Some rich-text paste paths split image markdown into:
+    // ![图片]
+    // (data:image/png;base64,...)
+    // Normalize that back into a valid Markdown image before rendering.
+    content = content.replace(
+        /!\[([^\]\n]*)\][ \t]*\n[ \t]*\((data:image\/(?:png|jpe?g|gif|webp|bmp);base64,[^)]+)\)/gi,
+        (_match, alt, url) => `![${alt}](${String(url).replace(/\s+/g, '')})`
+    );
+    content = content.replace(dataImageUrlPattern, (url) => url.replace(/\s+/g, ''));
     content = content.replace(/^[ ]{0,3}(\*[ ]*\*[ ]*\*[\* ]*)[ \t]*$/gm, '***');
     content = content.replace(/^[ ]{0,3}(-[ ]*-[ ]*-[- ]*)[ \t]*$/gm, '---');
     content = content.replace(/^[ ]{0,3}(_[ ]*_[ ]*_[_ ]*)[ \t]*$/gm, '___');

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -40,7 +40,7 @@ export function preprocessMarkdown(content: string) {
     // (data:image/png;base64,...)
     // Normalize that back into a valid Markdown image before rendering.
     content = content.replace(
-        /!\[([^\]\n]*)\][ \t]*\n[ \t]*\((data:image\/(?:png|jpe?g|gif|webp|bmp);base64,[^)]+)\)/gi,
+        /!\[([^\]\n]*)\][ \t]*(?:\r?\n[ \t]*)+\((data:image\/(?:png|jpe?g|gif|webp|bmp);base64,[^)]+)\)/gi,
         (_match, alt, url) => `![${alt}](${String(url).replace(/\s+/g, '')})`
     );
     content = content.replace(dataImageUrlPattern, (url) => url.replace(/\s+/g, ''));

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -25,6 +25,13 @@ export const md = new MarkdownIt({
     }
 });
 
+const defaultValidateLink = md.validateLink.bind(md);
+const safeDataImagePattern = /^data:image\/(?:png|jpe?g|gif|webp|bmp);base64,[a-z0-9+/=\s]+$/i;
+
+md.validateLink = (url: string) => {
+    return defaultValidateLink(url) || safeDataImagePattern.test(url);
+};
+
 // Avoid bold fragmentation when pasting from certain apps
 export function preprocessMarkdown(content: string) {
     content = content.replace(/^[ ]{0,3}(\*[ ]*\*[ ]*\*[\* ]*)[ \t]*$/gm, '***');


### PR DESCRIPTION
## Summary

Fixes pasted Markdown image syntax that uses `data:image/...;base64` URLs so Raphael renders it as an actual image instead of leaving the long base64 payload visible as article text.

## Root cause

The paste pipeline already preserved full data URLs, but markdown-it's default link validation rejects `data:` URLs. As a result, Markdown like `![图片](data:image/png;base64,...)` could leak into the editor/preview as raw text instead of becoming an `<img>`.

## Changes

- Allow only safe raster `data:image/*;base64` URLs through Markdown link validation.
- Keep arbitrary non-image `data:` URLs blocked.
- Add unit coverage for rendering base64 image Markdown and rejecting `data:text/html`.
- Add a Playwright regression test that verifies the preview renders a base64 image and does not show the data URL text.
- Make e2e navigation wait for `domcontentloaded` so external default-content images do not make unrelated tests flaky.

## Verification

- `pnpm test`
- `pnpm build`
- `pnpm test:e2e`