### PR TITLE
Improve image handling for paste and export

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { PenLine, Eye } from 'lucide-react';
 import html2pdf from 'html2pdf.js';
 import { md, preprocessMarkdown, applyTheme } from './lib/markdown';
 import { markElementIndexes } from './lib/markdownIndexer';
-import { makeWeChatCompatible, cleanInternalAttributes } from './lib/wechatCompat';
+import { makeWeChatCompatible, cleanInternalAttributes, inlineImagesAsBase64, inlineImagesInHtml } from './lib/wechatCompat';
 import { THEMES } from './lib/themes';
 import { defaultContent } from './defaultContent';
 import { findImagePosition, selectTextAreaRange } from './lib/imageSelector';
@@ -145,7 +145,8 @@ export default function App() {
         if (!previewRef.current) return;
         setIsCopying(true);
         try {
-            const finalHtmlForCopy = await makeWeChatCompatible(renderedHtml, activeTheme);
+            const compatibleHtml = await makeWeChatCompatible(renderedHtml, activeTheme);
+            const finalHtmlForCopy = await inlineImagesInHtml(compatibleHtml);
 
             const blob = new Blob([finalHtmlForCopy], { type: 'text/html' });
             const textBlob = new Blob([previewRef.current.innerText], { type: 'text/plain' });
@@ -166,19 +167,24 @@ export default function App() {
         }
     };
 
-    const handleExportHtml = () => {
-        // Clean internal attributes before exporting
-        const cleanHtml = cleanInternalAttributes(renderedHtml);
-        const blob = new Blob([cleanHtml], { type: 'text/html;charset=utf-8' });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `Raphael_Article_${new Date().getTime()}.html`;
-        a.click();
-        URL.revokeObjectURL(url);
+    const handleExportHtml = async () => {
+        try {
+            const cleanHtml = cleanInternalAttributes(renderedHtml);
+            const exportHtml = await inlineImagesInHtml(cleanHtml);
+            const blob = new Blob([exportHtml], { type: 'text/html;charset=utf-8' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = `Raphael_Article_${new Date().getTime()}.html`;
+            a.click();
+            URL.revokeObjectURL(url);
+        } catch (err) {
+            console.error('Export HTML failed', err);
+            alert('导出 HTML 失败，请重试');
+        }
     };
 
-    const handleExportPdf = () => {
+    const handleExportPdf = async () => {
         if (!previewRef.current) return;
         const element = previewRef.current;
         const opt = {
@@ -201,10 +207,18 @@ export default function App() {
         cloneContainer.style.background = document.documentElement.classList.contains('dark') ? '#000000' : '#ffffff';
         cloneContainer.appendChild(clonedElement);
 
-        document.body.appendChild(cloneContainer);
-        html2pdf().set(opt).from(cloneContainer).save().then(() => {
-            document.body.removeChild(cloneContainer);
-        });
+        try {
+            await inlineImagesAsBase64(cloneContainer);
+            document.body.appendChild(cloneContainer);
+            await html2pdf().set(opt).from(cloneContainer).save();
+        } catch (err) {
+            console.error('Export PDF failed', err);
+            alert('导出 PDF 失败，请重试');
+        } finally {
+            if (cloneContainer.parentNode) {
+                document.body.removeChild(cloneContainer);
+            }
+        }
     };
 
     const handleImageClick = useCallback((info: { type: string; index: number; src?: string; alt?: string; content?: string }) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,9 +14,38 @@ import Toolbar from './components/Toolbar';
 import EditorPanel from './components/EditorPanel';
 import PreviewPanel from './components/PreviewPanel';
 
+const MARKDOWN_CACHE_KEY = 'raphael-publish:markdown-input';
+const MARKDOWN_PERSIST_DEBOUNCE_MS = 300;
+
+function persistMarkdownInput(value: string) {
+    try {
+        if (value === '') {
+            window.localStorage.removeItem(MARKDOWN_CACHE_KEY);
+            return;
+        }
+
+        window.localStorage.setItem(MARKDOWN_CACHE_KEY, value);
+    } catch (error) {
+        console.error('Persist markdown failed', error);
+    }
+}
+
+function getInitialMarkdownInput() {
+    if (typeof window === 'undefined') return defaultContent;
+
+    try {
+        const cachedMarkdown = window.localStorage.getItem(MARKDOWN_CACHE_KEY);
+        if (cachedMarkdown === '') return defaultContent;
+        return cachedMarkdown ?? defaultContent;
+    } catch (error) {
+        console.error('Load cached markdown failed', error);
+        return defaultContent;
+    }
+}
+
 export default function App() {
     const [themeMode, setThemeMode] = useState<'light' | 'dark'>('light');
-    const [markdownInput, setMarkdownInput] = useState<string>(defaultContent);
+    const [markdownInput, setMarkdownInput] = useState<string>(getInitialMarkdownInput);
     const [renderedHtml, setRenderedHtml] = useState<string>('');
     const [activeTheme, setActiveTheme] = useState(THEMES[0].id);
     const [copied, setCopied] = useState(false);
@@ -30,10 +59,60 @@ export default function App() {
     const previewInnerScrollRef = useRef<HTMLDivElement>(null);
     const scrollSyncLockRef = useRef<'editor' | 'preview' | null>(null);
     const scrollLockReleaseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const markdownInputRef = useRef(markdownInput);
+    const markdownPersistTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     useEffect(() => {
         // Enforce light mode as default, do not follow system preferences
     }, []);
+
+    useEffect(() => {
+        markdownInputRef.current = markdownInput;
+    }, [markdownInput]);
+
+    const flushMarkdownInput = useCallback(() => {
+        if (markdownPersistTimeoutRef.current) {
+            clearTimeout(markdownPersistTimeoutRef.current);
+            markdownPersistTimeoutRef.current = null;
+        }
+
+        persistMarkdownInput(markdownInputRef.current);
+    }, []);
+
+    useEffect(() => {
+        if (markdownPersistTimeoutRef.current) {
+            clearTimeout(markdownPersistTimeoutRef.current);
+        }
+
+        markdownPersistTimeoutRef.current = setTimeout(() => {
+            persistMarkdownInput(markdownInput);
+            markdownPersistTimeoutRef.current = null;
+        }, MARKDOWN_PERSIST_DEBOUNCE_MS);
+
+        return () => {
+            if (markdownPersistTimeoutRef.current) {
+                clearTimeout(markdownPersistTimeoutRef.current);
+                markdownPersistTimeoutRef.current = null;
+            }
+        };
+    }, [markdownInput]);
+
+    useEffect(() => {
+        const handleVisibilityChange = () => {
+            if (document.visibilityState === 'hidden') {
+                flushMarkdownInput();
+            }
+        };
+
+        window.addEventListener('blur', flushMarkdownInput);
+        document.addEventListener('visibilitychange', handleVisibilityChange);
+
+        return () => {
+            window.removeEventListener('blur', flushMarkdownInput);
+            document.removeEventListener('visibilitychange', handleVisibilityChange);
+            flushMarkdownInput();
+        };
+    }, [flushMarkdownInput]);
 
     const toggleTheme = () => {
         setThemeMode((prev) => {

--- a/src/lib/htmlToMarkdown.test.ts
+++ b/src/lib/htmlToMarkdown.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { insertAtSelection } from './htmlToMarkdown';
+import { handleSmartPaste, insertAtSelection } from './htmlToMarkdown';
 
 describe('insertAtSelection', () => {
+    const originalCreateObjectURL = URL.createObjectURL;
+
     beforeEach(() => {
         vi.useFakeTimers();
     });
@@ -9,6 +11,8 @@ describe('insertAtSelection', () => {
     afterEach(() => {
         vi.runOnlyPendingTimers();
         vi.useRealTimers();
+        vi.restoreAllMocks();
+        URL.createObjectURL = originalCreateObjectURL;
         document.body.innerHTML = '';
     });
 
@@ -49,5 +53,42 @@ describe('insertAtSelection', () => {
 
         expect(textarea.selectionStart).toBe('hello Raphael'.length);
         expect(textarea.selectionEnd).toBe('hello Raphael'.length);
+    });
+
+    it('pastes clipboard images as blob object URLs', async () => {
+        const textarea = createTextarea('hello ');
+        textarea.selectionStart = textarea.selectionEnd = textarea.value.length;
+
+        const file = new File(['png'], 'clip.png', { type: 'image/png' });
+        const setMarkdownInput = vi.fn((value: string) => {
+            textarea.value = value;
+        });
+        URL.createObjectURL = vi.fn(() => 'blob:http://localhost/pasted-image') as typeof URL.createObjectURL;
+
+        const event = {
+            clipboardData: {
+                items: [
+                    {
+                        kind: 'file',
+                        type: 'image/png',
+                        getAsFile: () => file
+                    }
+                ],
+                files: [file],
+                getData: vi.fn(() => '')
+            },
+            currentTarget: textarea,
+            preventDefault: vi.fn()
+        } as unknown as React.ClipboardEvent<HTMLTextAreaElement>;
+
+        handleSmartPaste(event, setMarkdownInput);
+        await Promise.resolve();
+        vi.runAllTimers();
+
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(URL.createObjectURL).toHaveBeenCalledWith(file);
+        expect(setMarkdownInput).toHaveBeenCalledWith('hello ![图片](blob:http://localhost/pasted-image)');
+        expect(textarea.selectionStart).toBe(textarea.value.length);
+        expect(textarea.selectionEnd).toBe(textarea.value.length);
     });
 });

--- a/src/lib/htmlToMarkdown.ts
+++ b/src/lib/htmlToMarkdown.ts
@@ -89,13 +89,8 @@ function getClipboardImageFiles(clipboardData: DataTransfer): File[] {
     return Array.from(clipboardData.files || []).filter((file) => file.type.startsWith('image/'));
 }
 
-function fileToDataUrl(file: File): Promise<string> {
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = () => resolve(String(reader.result || ''));
-        reader.onerror = () => reject(reader.error || new Error('Failed to read clipboard image'));
-        reader.readAsDataURL(file);
-    });
+function fileToObjectUrl(file: File): string {
+    return URL.createObjectURL(file);
 }
 
 export function insertAtSelection(
@@ -131,20 +126,19 @@ export function handleSmartPaste(
         e.preventDefault();
         const textarea = e.currentTarget;
 
-        Promise.all(imageFiles.map(fileToDataUrl))
-            .then((dataUrls) => {
-                const markdownImages = dataUrls
-                    .filter(Boolean)
-                    .map((src, index) => `![图片${dataUrls.length > 1 ? ` ${index + 1}` : ''}](${src})`)
-                    .join('\n\n');
+        try {
+            const objectUrls = imageFiles.map(fileToObjectUrl);
+            const markdownImages = objectUrls
+                .filter(Boolean)
+                .map((src, index) => `![图片${objectUrls.length > 1 ? ` ${index + 1}` : ''}](${src})`)
+                .join('\n\n');
 
-                if (!markdownImages) return;
-                insertAtSelection(textarea, markdownImages, setMarkdownInput);
-            })
-            .catch((err) => {
-                console.error('Clipboard image conversion failed:', err);
-                alert('粘贴图片失败，请重试');
-            });
+            if (!markdownImages) return;
+            insertAtSelection(textarea, markdownImages, setMarkdownInput);
+        } catch (err) {
+            console.error('Clipboard image conversion failed:', err);
+            alert('粘贴图片失败，请重试');
+        }
         return;
     }
 

--- a/src/lib/wechatCompat.test.ts
+++ b/src/lib/wechatCompat.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getBase64Image } from './wechatCompat';
+
+describe('getBase64Image', () => {
+    const originalFetch = globalThis.fetch;
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        globalThis.fetch = originalFetch;
+    });
+
+    it('returns the original URL when the fetched response is not an image', async () => {
+        const imgUrl = 'https://example.com/not-an-image';
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            blob: vi.fn().mockResolvedValue(new Blob(['plain text'], { type: 'text/plain' }))
+        } as unknown as Response);
+
+        globalThis.fetch = fetchMock as typeof fetch;
+
+        await expect(getBase64Image(imgUrl)).resolves.toBe(imgUrl);
+        expect(fetchMock).toHaveBeenCalledWith(imgUrl, { mode: 'cors', cache: 'default' });
+    });
+});

--- a/src/lib/wechatCompat.ts
+++ b/src/lib/wechatCompat.ts
@@ -13,7 +13,7 @@ export function cleanInternalAttributes(html: string): string {
 }
 
 // Helper to convert images to Base64
-async function getBase64Image(imgUrl: string): Promise<string> {
+export async function getBase64Image(imgUrl: string): Promise<string> {
     try {
         if (imgUrl.startsWith('data:')) return imgUrl;
 
@@ -21,6 +21,8 @@ async function getBase64Image(imgUrl: string): Promise<string> {
         if (!response.ok) return imgUrl;
 
         const blob = await response.blob();
+        if (!blob.type.startsWith('image/')) return imgUrl;
+
         return new Promise((resolve) => {
             const reader = new FileReader();
             reader.onloadend = () => resolve(reader.result as string);
@@ -30,6 +32,24 @@ async function getBase64Image(imgUrl: string): Promise<string> {
     } catch (e) {
         return imgUrl;
     }
+}
+
+export async function inlineImagesAsBase64(root: ParentNode): Promise<void> {
+    const imgs = Array.from(root.querySelectorAll('img'));
+    await Promise.all(imgs.map(async img => {
+        const src = img.getAttribute('src');
+        if (!src || src.startsWith('data:')) return;
+
+        const base64 = await getBase64Image(src);
+        img.setAttribute('src', base64);
+    }));
+}
+
+export async function inlineImagesInHtml(html: string): Promise<string> {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    await inlineImagesAsBase64(doc);
+    return doc.body.innerHTML;
 }
 
 export async function makeWeChatCompatible(html: string, themeId: string): Promise<string> {
@@ -184,14 +204,7 @@ export async function makeWeChatCompatible(html: string, themeId: string): Promi
     });
 
     // 5. Convert all images to Base64 for safe WeChat pasting
-    const imgs = Array.from(section.querySelectorAll('img'));
-    await Promise.all(imgs.map(async img => {
-        const src = img.getAttribute('src');
-        if (src && !src.startsWith('data:')) {
-            const base64 = await getBase64Image(src);
-            img.setAttribute('src', base64);
-        }
-    }));
+    await inlineImagesAsBase64(section);
 
     doc.body.innerHTML = '';
     doc.body.appendChild(section);


### PR DESCRIPTION
## Summary
- keep pasted images as blob URLs during editing and convert them only when exporting or copying for WeChat
- add a shared image inlining path for export / WeChat compatibility
- fall back to the original URL when fetch returns a non-image MIME type

## Related
- related to #21 by keeping inline image data out of the editor during editing

## Preview
<img width=2560 height=1272 alt=image src=https://github.com/user-attachments/assets/9988e4b7-b0e2-4bc0-8075-c81344343dc3 />


## Verification
- npm test -- src/lib/wechatCompat.test.ts
- npm run build